### PR TITLE
Automatización de la configuración de router con Ansible

### DIFF
--- a/router/files/99-router.conf
+++ b/router/files/99-router.conf
@@ -1,0 +1,4 @@
+# /etc/sysctl.d/99-router.conf
+
+net.ipv4.ip_forward=1
+net.ipv6.conf.all.forwarding=1

--- a/router/files/armbian.yaml
+++ b/router/files/armbian.yaml
@@ -1,0 +1,28 @@
+# /etc/netplan/armbian.yaml
+
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    wan:
+      addresses:
+      - "132.248.59.72/24"
+      nameservers:
+        addresses:
+        - 9.9.9.9
+        - 1.1.1.1
+      dhcp4: false
+      dhcp6: false
+      macaddress: "ee:5d:d7:97:2e:14"
+      routes:
+      - metric: 200
+        to: "0.0.0.0/0"
+        via: "132.248.59.254"
+    lan: {}
+  bridges:
+    br0:
+      interfaces:
+      - lan
+      dhcp4: false
+      addresses:
+      - "10.8.24.1/24"

--- a/router/files/lan.conf
+++ b/router/files/lan.conf
@@ -1,0 +1,18 @@
+# /etc/dnsmasq.d/lan.conf
+
+# DHCP range for LAN
+interface=br0
+bind-interfaces
+domain-needed
+bogus-priv
+
+# IP range and lease time
+dhcp-range=10.8.24.10,10.8.24.100,12h
+
+# Optional: Set gateway and DNS for clients
+dhcp-option=3,10.8.24.1    # default gateway
+dhcp-option=6,132.248.204.1    # DNS server
+
+# Optional: Local DNS resolution
+domain=lan
+expand-hosts

--- a/router/files/nftables.conf
+++ b/router/files/nftables.conf
@@ -1,0 +1,89 @@
+# /etc/nftables.conf
+
+#!/usr/sbin/nft -f
+
+# Flush existing ruleset
+flush ruleset
+
+# NAT Table for translating outgoing LAN traffic
+table ip nat {
+    chain prerouting {
+        type nat hook prerouting priority -100; policy accept;
+
+        # DNAT for HTTP/S
+        ip daddr 132.248.59.72 tcp dport 80 dnat to 10.8.24.20:80
+        ip daddr 132.248.59.72 tcp dport 443 dnat to 10.8.24.20:443
+
+	# DNAT for SSH/web
+        ip daddr 132.248.59.72 tcp dport 5210 dnat to 10.8.24.20:22
+    }
+
+    chain postrouting {
+        type nat hook postrouting priority 100; policy accept;
+
+        # SNAT traffic leaving via the WAN interface
+        oif "wan" snat to 132.248.59.72
+
+        # Hairpin NAT: fix LAN to public IP loopback
+        ip saddr 10.8.24.0/24 ip daddr 10.8.24.20 snat to 10.8.24.1
+    }
+}
+
+# Filter Table for packet filtering
+table ip filter {
+    # Traffic destined to the router itself
+    chain input {
+        type filter hook input priority 0; policy drop;
+
+        # Allow traffic on the loopback interface
+        iif "lo" accept
+
+        # Allow established and related connections
+        ct state established,related accept
+
+	# Allow ICMP
+	ip protocol icmp accept
+
+        # Allow DHCP (UDP ports 67 and 68)
+        iif "br0" udp dport { 67, 68 } accept
+
+        # Allow DNS (UDP and TCP port 53)
+        iif "br0" udp dport 53 accept
+        iif "br0" tcp dport 53 accept
+
+        # Allow SSH (TCP port 22)
+        tcp dport 22 accept
+
+        # Allow HTTP and HTTPS
+        tcp dport { 80, 443 } accept
+
+        # Log and drop everything else (for troubleshooting)
+        log prefix "nft-input-drop: " counter drop
+    }
+
+    # Forward router traffic
+    chain forward {
+        type filter hook forward priority 0; policy drop;
+
+        # Allow established and related connections
+        ct state established,related accept
+
+        # Allow all traffic from the LAN interface (br0) out to the WAN
+        iif "br0" oif "wan" accept
+
+	# Allow packets coming from wan destined to LAN
+	iif "wan" oif "br0" accept
+
+        # Hairpin NAT: fix LAN to public IP loopback
+	ip saddr 10.8.24.0/24 ip daddr 10.8.24.20 accept
+
+        # Log and drop everything else (for troubleshooting)
+        log prefix "nft-input-drop: " counter drop
+    }
+
+
+    # Output the router’s own traffic
+    chain output {
+        type filter hook output priority 0; policy accept;
+    }
+}

--- a/router/inventory.yml
+++ b/router/inventory.yml
@@ -1,0 +1,6 @@
+all:
+  children:
+    routers:
+      hosts:
+        router_01:
+          ansible_host: x.x.x.x

--- a/router/router.yml
+++ b/router/router.yml
@@ -1,0 +1,85 @@
+- name: Ansible playbook that automates router configuration
+  hosts: routers
+  become: true
+
+  tasks:
+
+# Apply basic configuration
+
+    - ansible.builtin.import_tasks: tasks/unattended-upgrades.yml
+    - ansible.builtin.import_tasks: tasks/sshd.yml
+
+# Copy /etc/netplan/armbian.yml
+
+    - name: Copy armbian.yml file
+      ansible.builtin.copy:
+        src: files/armbian.yml
+        dest: /etc/netplan/armbian.yml
+        mode: '0744'
+        owner: root
+        group: root
+
+# Copy /etc/dnsmasq/lan.conf
+
+    - name: Ensure that dnsmasq in installed
+      ansible.builtin.apt:
+        name: dnsmasq
+        state: present
+        update_cache: yes
+
+    - name: Copy lan.conf file
+      ansible.builtin.copy:
+        src: files/lan.conf
+        dest: /etc/dnsmasq/lan.conf
+        mode: '0744'
+        owner: root
+        group: root
+
+# Copy /etc/nftables.conf
+
+    - name: Ensure that nftables in installed
+      ansible.builtin.apt:
+        name: nftables
+        state: present
+        update_cache: yes
+
+    - name: Copy nftables.conf file
+      ansible.builtin.copy:
+        src: files/nftables.conf
+        dest: /etc/ntftables.conf
+        mode: '0744'
+        owner: root
+        group: root
+
+# Copy /etc/sysctl.d/99-router.conf
+
+    - name: Copy 99-router.conf file
+      ansible.builtin.copy:
+        src: files/99-router.conf
+        dest: /etc/sysctl.d/99-router.conf
+        mode: '0744'
+        owner: root
+        group: root
+
+# Start services
+
+    - name: Reload daemons
+      ansible.builtin.systemd:
+        daemon_reload: yes
+
+    - name: Start dnsmasq service
+      ansible.builtin.service:
+        name: dnsmasq.service
+        state: started
+        enabled: true
+
+    - name: Start nftables service
+      ansible.builtin.service:
+        name: nftables.service
+        state: started
+        enabled: true
+
+# Reboot machine to load armbian.yml
+
+    - name: Reboot the machine
+      ansible.builtin.reboot:

--- a/router/tasks/sshd.yml
+++ b/router/tasks/sshd.yml
@@ -1,0 +1,13 @@
+---
+    - name: sshd secure configuration
+      ansible.builtin.blockinfile:
+        name: /etc/ssh/sshd_config
+        block: |
+          Port 22
+          PermitRootLogin no
+          PasswordAuthentication no
+          PubkeyAuthentication yes
+          X11Forwarding no
+        marker: "# {mark} sshd configuration"
+        insertafter: EOF
+...

--- a/router/tasks/unnatended-upgrades.yml
+++ b/router/tasks/unnatended-upgrades.yml
@@ -1,0 +1,15 @@
+---
+    - name: Install unnatended-upgrades and apt-listchanges
+      ansible.builtin.apt:
+        name:
+          - unattended-upgrades
+          - apt-listchanges
+        state: present
+        update_cache: yes
+
+    - name: Enable autoupdates
+      ansible.builtin.shell: echo unattended-upgrades unattended-upgrades/enable_auto_updates boolean true | debconf-set-selections
+
+    - name: DPKG reconfigure
+      ansible.builtin.command: dpkg-reconfigure -f noninteractive unattended-upgrades
+...


### PR DESCRIPTION
Se agrega el playbook **`router.yml`** y tasks necesarias para automatizar la configuración de un router.

Dentro de las configuraciones básicas, se incluyen las `unattended-upgrades` y la configuración segura de `sshd`.

Para la configuración del router,  incluye la instalación y arranque de los servicios de `dnsmasq` y `nftables`.

Los archivos de configuración copiados son los siguientes:

- `/etc/netplan/armbian.yml`
- `/etc/dnsmasq/lan.conf`
- `/etc/nftables.conf`
- `/etc/sysctl.d/99-router.conf`